### PR TITLE
Repath render elements

### DIFF
--- a/templates/3dsmax/scripts/3dsmax.ps1
+++ b/templates/3dsmax/scripts/3dsmax.ps1
@@ -163,7 +163,7 @@ if ($renderer -like "vray")
 
 if ((Test-Path ".\RepathRenderElements.ms"))
 {
-	$remapRenderElementsScript = (Get-Content -Path ".\RepathRenderElements.ms")
+	$remapRenderElementsScript = (Get-Content -Path ".\RepathRenderElements.ms" -Raw)
 	$pre_render_script_content += "-- Remap any render element paths`r`n"
 	$pre_render_script_content += $remapRenderElementsScript
 }

--- a/templates/3dsmax/scripts/3dsmax.ps1
+++ b/templates/3dsmax/scripts/3dsmax.ps1
@@ -161,6 +161,13 @@ if ($renderer -like "vray")
     $pre_render_script_content += "if index == 1 then (r.output_splitfilename = ""$outputFiles"")`r`n"
 }
 
+if ((Test-Path ".\RepathRenderElements.ms"))
+{
+	$remapRenderElementsScript = (Get-Content -Path ".\RepathRenderElements.ms")
+	$pre_render_script_content += "-- Remap any render element paths`r`n"
+	$pre_render_script_content += $remapRenderElementsScript
+}
+
 $pre_render_script_content | Out-File $pre_render_script -Encoding ASCII
 
 if (ParameterValueSet $preRenderScript)

--- a/templates/3dsmax/scripts/RepathRenderElements.ms
+++ b/templates/3dsmax/scripts/RepathRenderElements.ms
@@ -1,0 +1,16 @@
+sysEnv = dotNetClass "System.Environment"
+rem = maxOps.GetCurRenderElementMgr()
+for n = 0 to (rem.NumRenderElements() - 1) do
+(
+	el = rem.GetRenderElement n
+	originalPath = rem.GetRenderElementFileName n
+	if (el.enabled and originalPath != undefined and originalPath != "") then
+	(
+		tokens = filterString originalPath "\\"
+		filename = tokens[tokens.count]
+		prefix = sysEnv.GetEnvironmentVariable "AZ_BATCH_TASK_WORKING_DIR"
+		newPath = prefix + "\\images\\" + filename
+		format "\nUpdating render element path % => %" originalPath newPath
+		rem.SetRenderElementFilename n newPath
+	)
+)

--- a/templates/3dsmax/standard/job.template.json
+++ b/templates/3dsmax/standard/job.template.json
@@ -192,8 +192,12 @@
                     "commandLine": "powershell.exe 3dsmax.ps1 -maxVersion \\\"[parameters('maxVersion')]\\\" -start {0} -end {0} -outputName \\\"images\\[parameters('outputName')]\\\" -sceneFile \\\"[parameters('sceneFile')]\\\" -pathFile \\\"[parameters('pathFile')]\\\" -renderer [parameters('renderer')] -preRenderScript \\\"[parameters('preRenderScript')]\\\" -camera \\\"[parameters('camera')]\\\" -additionalArgs \\\" [parameters('additionalArgs')]\\\" -irradianceMap \\\"[parameters('irradianceMapFile')]\\\" -renderPresetFile \\\"[parameters('renderPresetFile')]\\\"",
                     "resourceFiles":[
                         {
-                            "blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/master/templates/3dsmax/scripts/3dsmax.ps1",
+                            "blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/repath-render-elements/templates/3dsmax/scripts/3dsmax.ps1",
                             "filePath":"3dsmax.ps1"
+                        },
+                        {
+                            "blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/repath-render-elements/templates/3dsmax/scripts/RepathRenderElements.ms",
+                            "filePath":"RepathRenderElements.ms"
                         }
                     ],
                     "outputFiles": [

--- a/templates/3dsmax/standard/job.template.json
+++ b/templates/3dsmax/standard/job.template.json
@@ -192,11 +192,11 @@
                     "commandLine": "powershell.exe 3dsmax.ps1 -maxVersion \\\"[parameters('maxVersion')]\\\" -start {0} -end {0} -outputName \\\"images\\[parameters('outputName')]\\\" -sceneFile \\\"[parameters('sceneFile')]\\\" -pathFile \\\"[parameters('pathFile')]\\\" -renderer [parameters('renderer')] -preRenderScript \\\"[parameters('preRenderScript')]\\\" -camera \\\"[parameters('camera')]\\\" -additionalArgs \\\" [parameters('additionalArgs')]\\\" -irradianceMap \\\"[parameters('irradianceMapFile')]\\\" -renderPresetFile \\\"[parameters('renderPresetFile')]\\\"",
                     "resourceFiles":[
                         {
-                            "blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/repath-render-elements/templates/3dsmax/scripts/3dsmax.ps1",
+                            "blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/master/templates/3dsmax/scripts/3dsmax.ps1",
                             "filePath":"3dsmax.ps1"
                         },
                         {
-                            "blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/repath-render-elements/templates/3dsmax/scripts/RepathRenderElements.ms",
+                            "blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/master/templates/3dsmax/scripts/RepathRenderElements.ms",
                             "filePath":"RepathRenderElements.ms"
                         }
                     ],

--- a/templates/3dsmax/vray-dr/job.template.json
+++ b/templates/3dsmax/vray-dr/job.template.json
@@ -197,11 +197,11 @@
                         },
                         "resourceFiles":[
 							{
-								"blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/repath-render-elements/templates/3dsmax/scripts/3dsmax.ps1",
+								"blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/master/templates/3dsmax/scripts/3dsmax.ps1",
 								"filePath":"3dsmax.ps1"
 							},
 							{
-								"blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/repath-render-elements/templates/3dsmax/scripts/RepathRenderElements.ms",
+								"blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/master/templates/3dsmax/scripts/RepathRenderElements.ms",
 								"filePath":"RepathRenderElements.ms"
 							}
                         ],

--- a/templates/3dsmax/vray-dr/job.template.json
+++ b/templates/3dsmax/vray-dr/job.template.json
@@ -196,10 +196,14 @@
                             "coordinationCommandLine":"cmd.exe /c echo noop"
                         },
                         "resourceFiles":[
-                            {
-                                "blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/master/templates/3dsmax/scripts/3dsmax.ps1",
-                                "filePath":"3dsmax.ps1"
-                            }
+							{
+								"blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/repath-render-elements/templates/3dsmax/scripts/3dsmax.ps1",
+								"filePath":"3dsmax.ps1"
+							},
+							{
+								"blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/repath-render-elements/templates/3dsmax/scripts/RepathRenderElements.ms",
+								"filePath":"RepathRenderElements.ms"
+							}
                         ],
                         "outputFiles":[
                             {

--- a/templates/3dsmax/vray-dr/job.template.json
+++ b/templates/3dsmax/vray-dr/job.template.json
@@ -196,14 +196,14 @@
                             "coordinationCommandLine":"cmd.exe /c echo noop"
                         },
                         "resourceFiles":[
-							{
-								"blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/master/templates/3dsmax/scripts/3dsmax.ps1",
-								"filePath":"3dsmax.ps1"
-							},
-							{
-								"blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/master/templates/3dsmax/scripts/RepathRenderElements.ms",
-								"filePath":"RepathRenderElements.ms"
-							}
+                            {
+                                "blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/master/templates/3dsmax/scripts/3dsmax.ps1",
+                                "filePath":"3dsmax.ps1"
+                            },
+                            {
+                                "blobSource":"https://raw.githubusercontent.com/Azure/batch-extension-templates/master/templates/3dsmax/scripts/RepathRenderElements.ms",
+                                "filePath":"RepathRenderElements.ms"
+                            }
                         ],
                         "outputFiles":[
                             {


### PR DESCRIPTION
Render elements that use a path or drive that doesn't exist on the cloud nodes will cause the render to fail.  

We've introduced a MaxScript that will iterate through any enabled render elements and repath them to the local task working directory.