### PR TITLE
New rendering CentOS  image (1.1.5)

### DIFF
--- a/runner/Tests/TestConfiguration.json
+++ b/runner/Tests/TestConfiguration.json
@@ -268,7 +268,7 @@
     {
         "osType": "linux",
         "offer": "rendering-centos73",
-        "version": "1.1.3"
+        "version": "1.1.5"
     },
     {
         "publisher": "microsoft-azure-batch",

--- a/runner/Tests/TestConfigurationCentos.json
+++ b/runner/Tests/TestConfigurationCentos.json
@@ -1,0 +1,78 @@
+{
+  "tests": [
+    {
+        "name": "maya2017-default-linux",
+        "template": "../templates/maya/render-default-linux/job.template.json",
+        "poolTemplate": "../templates/maya/render-default-linux/pool.template.json",
+        "parameters": "Tests/maya/render-default-linux/job.parameters2017.json",
+        "expectedOutput":"maya.exr.0001"
+    },
+    {
+        "name": "arnold-linux-frames",
+        "template": "../templates/arnold/render-linux-frames/job.template.json",
+        "poolTemplate": "../templates/arnold/render-linux-frames/pool.template.json",
+        "parameters": "Tests/arnold/render-linux-frames/job.parameters.json",
+        "expectedOutput":"arnold.tif"
+    },
+    {
+        "name": "maya2018-default-linux",
+        "template": "../templates/maya/render-default-linux/job.template.json",
+        "poolTemplate": "../templates/maya/render-default-linux/pool.template.json",
+        "parameters": "Tests/maya/render-default-linux/job.parameters2018.json",
+        "expectedOutput":"maya.exr.0001"
+    },
+    {
+        "name": "maya2017-arnold-linux",
+        "template": "../templates/maya/render-arnold-linux/job.template.json",
+        "poolTemplate": "../templates/maya/render-arnold-linux/pool.template.json",
+        "parameters": "Tests/maya/render-arnold-linux/job.parameters2017.json",
+        "expectedOutput":"maya.exr.0001"
+    },
+    {
+        "name": "maya2018-arnold-linux",
+        "template": "../templates/maya/render-arnold-linux/job.template.json",
+        "poolTemplate": "../templates/maya/render-arnold-linux/pool.template.json",
+        "parameters": "Tests/maya/render-arnold-linux/job.parameters2018.json",
+        "expectedOutput":"maya.exr.0001"
+    },
+    {
+        "name": "maya2017-vray-linux",
+        "template": "../templates/maya/render-vray-linux/job.template.json",
+        "poolTemplate": "../templates/maya/render-vray-linux/pool.template.json",
+        "parameters": "Tests/maya/render-vray-linux/job.parameters2017.json",
+        "expectedOutput":"maya-vray.0001.png"
+    },
+    {
+        "name": "maya2018-vray-linux",
+        "template": "../templates/maya/render-vray-linux/job.template.json",
+        "poolTemplate": "../templates/maya/render-vray-linux/pool.template.json",
+        "parameters": "Tests/maya/render-vray-linux/job.parameters2018.json",
+        "expectedOutput":"maya-vray.0001.png"
+    },
+    {
+        "name": "vray-render-linux",
+        "template": "../templates/vray/render-linux/job.template.json",
+        "poolTemplate": "../templates/vray/render-linux/pool.template.json",
+        "parameters": "Tests/vray/render-linux/job.parameters.json",
+        "expectedOutput":"image1.png"
+    }
+  ], 
+  "images": [
+    {
+        "osType": "windows",
+        "offer": "rendering-windows2016",
+        "version": "1.3.3"
+    },
+    {
+        "osType": "linux",
+        "offer": "rendering-centos73",
+        "version": "1.1.5"
+    },
+    {
+        "publisher": "microsoft-azure-batch",
+        "osType": "linux",
+        "offer": "centos-container",
+        "sku": "7-5",
+        "version": "latest"
+    }]
+}

--- a/runner/Tests/TestConfigurationCentosSmall.json
+++ b/runner/Tests/TestConfigurationCentosSmall.json
@@ -1,0 +1,36 @@
+{
+  "tests": [
+    {
+        "name": "arnold-linux-frames",
+        "template": "../templates/arnold/render-linux-frames/job.template.json",
+        "poolTemplate": "../templates/arnold/render-linux-frames/pool.template.json",
+        "parameters": "Tests/arnold/render-linux-frames/job.parameters.json",
+        "expectedOutput":"arnold.tif"
+    },    
+    {
+        "name": "vray-render-linux",
+        "template": "../templates/vray/render-linux/job.template.json",
+        "poolTemplate": "../templates/vray/render-linux/pool.template.json",
+        "parameters": "Tests/vray/render-linux/job.parameters.json",
+        "expectedOutput":"image1.png"
+    }
+  ], 
+  "images": [
+    {
+        "osType": "windows",
+        "offer": "rendering-windows2016",
+        "version": "1.3.3"
+    },
+    {
+        "osType": "centos",
+        "offer": "rendering-centos73",
+        "version": "1.1.5"
+    },
+    {
+        "publisher": "microsoft-azure-batch",
+        "osType": "linux",
+        "offer": "centos-container",
+        "sku": "7-5",
+        "version": "latest"
+    }]
+}

--- a/runner/custom_template_factory.py
+++ b/runner/custom_template_factory.py
@@ -151,7 +151,7 @@ def set_image_reference(in_memory_json_object: str, image_ref: 'List[utils.Image
     # if the json_object is Centos
     if "centos" in image_reference["offer"]:
         for i in range(0, len(image_ref)):
-            if image_ref[i].osType == "liunx":
+            if image_ref[i].osType == "centos":
                 set_image_reference_properties(image_reference, image_ref[i])
 
 

--- a/templates/arnold/render-linux-frames/job.template.json
+++ b/templates/arnold/render-linux-frames/job.template.json
@@ -53,7 +53,7 @@
                 "poolId": "[parameters('poolId')]"
             },
             "jobPreparationTask": {
-                "commandLine": "/bin/bash -c 'env'"
+                "commandLine": "/bin/bash -c 'env;export'"
             },
             "taskFactory": {
                 "type": "taskPerFile",
@@ -64,7 +64,7 @@
                     "displayName": "frame {fileNameWithoutExtension}",
                     "commandLine": "/bin/bash -c 'sudo mkdir -m a=rwx \"$AZ_BATCH_TASK_WORKING_DIR/images\";mkdir \"$AZ_BATCH_TASK_WORKING_DIR/assets\";/opt/solidangle/mtoa/2018/bin/kick -i \"$AZ_BATCH_TASK_WORKING_DIR/assets/{fileName}\" -dw -v 6 -of [parameters('outputFormat')] -o \"$AZ_BATCH_TASK_WORKING_DIR/images/{fileNameWithoutExtension}.[parameters('outputFormat')]\"'",                    "userIdentity": {
                         "autoUser": {
-                            "scope": "task",
+                            "scope": "pool",
                             "elevationLevel": "admin"
                         }
                     },

--- a/templates/arnold/render-linux-frames/job.template.json
+++ b/templates/arnold/render-linux-frames/job.template.json
@@ -53,7 +53,7 @@
                 "poolId": "[parameters('poolId')]"
             },
             "jobPreparationTask": {
-                "commandLine": "env;export"
+                "commandLine": "/bin/bash -c 'env'"
             },
             "taskFactory": {
                 "type": "taskPerFile",
@@ -62,8 +62,7 @@
                 },
                 "repeatTask": {
                     "displayName": "frame {fileNameWithoutExtension}",
-                    "commandLine": "sudo mkdir -m a=rwx \"$AZ_BATCH_TASK_WORKING_DIR/images\";/opt/solidangle/mtoa/2018/bin/kick -i \"$AZ_BATCH_TASK_WORKING_DIR/assets/{fileName}\" -dw -v 6 -of [parameters('outputFormat')] -o \"$AZ_BATCH_TASK_WORKING_DIR/images/{fileNameWithoutExtension}.[parameters('outputFormat')]\"",
-                    "userIdentity": {
+                    "commandLine": "/bin/bash -c 'sudo mkdir -m a=rwx \"$AZ_BATCH_TASK_WORKING_DIR/images\";mkdir \"$AZ_BATCH_TASK_WORKING_DIR/assets\";/opt/solidangle/mtoa/2018/bin/kick -i \"$AZ_BATCH_TASK_WORKING_DIR/assets/{fileName}\" -dw -v 6 -of [parameters('outputFormat')] -o \"$AZ_BATCH_TASK_WORKING_DIR/images/{fileNameWithoutExtension}.[parameters('outputFormat')]\"'",                    "userIdentity": {
                         "autoUser": {
                             "scope": "task",
                             "elevationLevel": "admin"

--- a/templates/arnold/render-linux-frames/pool.template.json
+++ b/templates/arnold/render-linux-frames/pool.template.json
@@ -98,7 +98,7 @@
                 "publisher": "batch",
                 "offer": "rendering-centos73",
                 "sku": "rendering",
-                "version": "1.1.3"
+                "version": "1.1.5"
             },
             "nodeAgentSKUId": "batch.node.centos 7"
         }

--- a/templates/maya/render-arnold-linux/pool.template.json
+++ b/templates/maya/render-arnold-linux/pool.template.json
@@ -82,7 +82,7 @@
                 "publisher": "batch",
                 "offer": "rendering-centos73",
                 "sku": "rendering",
-                "version": "1.1.3"
+                "version": "1.1.5"
             },
             "nodeAgentSKUId": "batch.node.centos 7"
         }

--- a/templates/maya/render-default-linux/job.template.json
+++ b/templates/maya/render-default-linux/job.template.json
@@ -131,8 +131,7 @@
                             "elevationLevel": "admin"
                         }
                     },
-                    "commandLine": "mkdir \"$AZ_BATCH_TASK_WORKING_DIR/thumbs\";sudo mkdir -m a=rwx -p \"/X\";sudo mount --rbind $AZ_BATCH_JOB_PREP_WORKING_DIR /X;export maya_exec=[parameters('mayaVersion')].sh;export maya_exec=${{maya_exec,,}};$maya_exec -r sw [parameters('additionalFlags')] -proj \"$AZ_BATCH_JOB_PREP_WORKING_DIR\" -rd \"$AZ_BATCH_TASK_WORKING_DIR/images\" -s {0} -e {0} \"/X/[parameters('sceneFile')]\";err=$?;sudo umount \"/X\";exit $err",                    
-                    "environmentSettings": [
+                    "commandLine": "/bin/bash -c 'set -e; set -o pipefail; mkdir \"$AZ_BATCH_TASK_WORKING_DIR/thumbs\";mkdir \"$AZ_BATCH_TASK_WORKING_DIR/images\";sudo mkdir -m a=rwx -p \"/X\";sudo mount --rbind $AZ_BATCH_JOB_PREP_WORKING_DIR /X;export maya_version=[parameters('mayaVersion')].sh;export maya_version=${{maya_version,,}};$maya_version -r arnold -ai:lve 1 [parameters('additionalFlags')] -proj \"$AZ_BATCH_JOB_PREP_WORKING_DIR\" -rd \"$AZ_BATCH_TASK_WORKING_DIR/images\" -s {0} -e {0} \"/X/[parameters('sceneFile')]\";err=$?;sudo umount \"/X\";exit $err'",                    "environmentSettings": [
                         {
                             "name": "MAYA_SCRIPT_PATH",
                             "value": "%AZ_BATCH_JOB_PREP_WORKING_DIR%/scripts"

--- a/templates/maya/render-default-linux/pool.template.json
+++ b/templates/maya/render-default-linux/pool.template.json
@@ -82,7 +82,7 @@
                 "publisher": "batch",
                 "offer": "rendering-centos73",
                 "sku": "rendering",
-                "version": "1.1.3"
+                "version": "1.1.5"
             },
             "nodeAgentSKUId": "batch.node.centos 7"
         }

--- a/templates/maya/render-vray-linux/job.template.json
+++ b/templates/maya/render-vray-linux/job.template.json
@@ -131,7 +131,7 @@
                             "elevationLevel": "admin"
                         }
                     },
-                    "commandLine": "mkdir \"$AZ_BATCH_TASK_WORKING_DIR/thumbs\";sudo mkdir -m a=rwx -p \"/X\";sudo mount --rbind $AZ_BATCH_JOB_PREP_WORKING_DIR /X;export maya_exec=[parameters('mayaVersion')].sh;export maya_exec=${{maya_exec,,}};$maya_exec -r vray [parameters('additionalFlags')] -proj \"$AZ_BATCH_JOB_PREP_WORKING_DIR\" -rd \"$AZ_BATCH_TASK_WORKING_DIR/images\" -s {0} -e {0} \"/X/[parameters('sceneFile')]\";err=$?;sudo umount \"/X\";exit $err",                    
+                    "commandLine": "/bin/bash -c 'set -e; set -o pipefail; mkdir \"$AZ_BATCH_TASK_WORKING_DIR/thumbs\" mkdir \"$AZ_BATCH_TASK_WORKING_DIR/images\";sudo mkdir -m a=rwx -p \"/X\";sudo mount --rbind $AZ_BATCH_JOB_PREP_WORKING_DIR /X;export maya_exec=[parameters('mayaVersion')].sh;export maya_exec=${{maya_exec,,}};$maya_exec -r vray [parameters('additionalFlags')] -proj \"$AZ_BATCH_JOB_PREP_WORKING_DIR\" -rd \"$AZ_BATCH_TASK_WORKING_DIR/images\" -s {0} -e {0} \"/X/[parameters('sceneFile')]\";err=$?;sudo umount \"/X\";exit $err'",                    
                     "environmentSettings": [
                         {
                             "name": "MAYA_SCRIPT_PATH",

--- a/templates/maya/render-vray-linux/pool.template.json
+++ b/templates/maya/render-vray-linux/pool.template.json
@@ -82,7 +82,7 @@
                 "publisher": "batch",
                 "offer": "rendering-centos73",
                 "sku": "rendering",
-                "version": "1.1.3"
+                "version": "1.1.5"
             },
             "nodeAgentSKUId": "batch.node.centos 7"
         }

--- a/templates/vray/render-linux/job.template.json
+++ b/templates/vray/render-linux/job.template.json
@@ -63,12 +63,6 @@
                 "poolId": "[parameters('poolId')]"
             },
             "jobPreparationTask": {
-                "userIdentity": {
-                    "autoUser": {
-                        "scope": "task",
-                        "elevationLevel": "admin"
-                    }
-                },
                 "resourceFiles": [
                     {
                         "source": {
@@ -92,7 +86,7 @@
                     "displayName": "Frame {0}",
                     "userIdentity": {
                         "autoUser": {
-                            "scope": "task",
+                            "scope": "pool",
                             "elevationLevel": "admin"
                         }
                     },

--- a/templates/vray/render-linux/job.template.json
+++ b/templates/vray/render-linux/job.template.json
@@ -63,6 +63,12 @@
                 "poolId": "[parameters('poolId')]"
             },
             "jobPreparationTask": {
+                "userIdentity": {
+                    "autoUser": {
+                        "scope": "task",
+                        "elevationLevel": "admin"
+                    }
+                },
                 "resourceFiles": [
                     {
                         "source": {
@@ -71,7 +77,7 @@
                         "filePath": "assets/"
                     }
                 ],
-                "commandLine": "ls"
+                "commandLine": "/bin/bash -c 'env'"
             },
             "taskFactory": {
                 "type": "parametricSweep",
@@ -90,7 +96,7 @@
                             "elevationLevel": "admin"
                         }
                     },
-                    "commandLine": "sudo mkdir -m a=rwx $AZ_BATCH_TASK_WORKING_DIR/images;sudo mkdir -m a=rwx -p \"/X\";sudo mount --rbind $AZ_BATCH_JOB_PREP_WORKING_DIR/assets /X;source /etc/profile.d/chaos.sh;vray2017.sh -sceneFile=\"/X/[parameters('sceneFile')]\" -frames={0} -imgfile=\"$AZ_BATCH_TASK_WORKING_DIR/images/image{0}.png\" -display=0;err=$?;sudo umount \"/X\";exit $err",
+                    "commandLine": "/bin/bash -c 'sudo mkdir -m a=rwx $AZ_BATCH_TASK_WORKING_DIR/images;sudo mkdir -m a=rwx -p \"/X\";sudo mount --rbind $AZ_BATCH_JOB_PREP_WORKING_DIR/assets /X;source /etc/profile.d/chaos.sh;vray2017.sh -sceneFile=\"/X/[parameters('sceneFile')]\" -frames={0} -imgfile=\"$AZ_BATCH_TASK_WORKING_DIR/images/image{0}.png\" -display=0;err=$?;sudo umount \"/X\";exit $err'",
                     "outputFiles": [
                         {
                             "filePattern": "../stdout.txt",

--- a/templates/vray/render-linux/pool.template.json
+++ b/templates/vray/render-linux/pool.template.json
@@ -97,7 +97,7 @@
                 "publisher": "batch",
                 "offer": "rendering-centos73",
                 "sku": "rendering",
-                "version": "1.1.2"
+                "version": "1.1.5"
             },
             "nodeAgentSKUId": "batch.node.centos 7"
         }


### PR DESCRIPTION
- Updated centos templates to use the 1.1.5 rendering images
- Fixed a small bug with running centos '-preview' images in the test config files.
- Updated all centos templates to use 1.1.5
- Added a test config file used for testing the centos based rendering image.
- Fixing the commandline tasks so they work so they don't include 'cmd /c' for the centos images. 
